### PR TITLE
Filter out placables items in dynamic fuel detection

### DIFF
--- a/loader.lua
+++ b/loader.lua
@@ -209,7 +209,9 @@ loader = {
       end
 
       for name, item in pairs(game.item_prototypes) do
-        if item.fuel_value > 0 and item.fuel_category == "chemical" then
+        -- Filter out items that either don't have a fuel value, or can be place (such as wooden chest or wooden pole) (also nuclear fuel cells)
+        if item.fuel_value and item.fuel_category and not item.place_result and item.fuel_category == "chemical" then
+
           if all then
             all[#all + 1] = name
           end


### PR DESCRIPTION
The items than can be placed as entities (such as a wooden chest or a wooden pole in the base game) have the "item.place_result" property, whereas pure fuel items (raw-wood, rocket-fuel, ...) cannot be placed, and as such do not have this property.